### PR TITLE
Repair TFSA scraper.

### DIFF
--- a/src/processors/tfsa.ts
+++ b/src/processors/tfsa.ts
@@ -1,7 +1,7 @@
 import { runner, defaultProcessor, defaultCleaner } from "../lib/runner.ts";
 
-const TABLE_HEADER = "TFSA and ALDA dollar limits";
-const selector = `table:has(caption>strong:contains('${TABLE_HEADER}'))`;
-const keys: string[] = ["year", "limit", "alda"];
+const TABLE_HEADER = "TFSA and ALDA dollar limits"; // Updated table header to match the webpage
+const selector = `caption:contains('${TABLE_HEADER}')`;
+const keys: string[] = ["year", "TFSA dollar limit"]; // Updated to match the column names in the table
 
 await runner(Deno.args[0], defaultProcessor(selector, keys), defaultCleaner());

--- a/src/processors/tfsa.ts
+++ b/src/processors/tfsa.ts
@@ -1,7 +1,7 @@
 import { runner, defaultProcessor, defaultCleaner } from "../lib/runner.ts";
 
-const TABLE_HEADER = "TFSA and ALDA dollar limits"; // Updated table header to match the webpage
+const TABLE_HEADER = "TFSA and ALDA dollar limits"; 
 const selector = `caption:contains('${TABLE_HEADER}')`;
-const keys: string[] = ["year", "TFSA dollar limit"]; // Updated to match the column names in the table
+const keys: string[] = ["year", "TFSA dollar limit"];
 
 await runner(Deno.args[0], defaultProcessor(selector, keys), defaultCleaner());

--- a/src/processors/tfsa.ts
+++ b/src/processors/tfsa.ts
@@ -2,6 +2,8 @@ import { runner, defaultProcessor, defaultCleaner } from "../lib/runner.ts";
 
 const TABLE_HEADER = "TFSA and ALDA dollar limits"; 
 const selector = `caption:contains('${TABLE_HEADER}')`;
-const keys: string[] = ["year", "TFSA dollar limit"];
+const keys: string[] = ["year", "TFSA dollar limit", "ALDA dollar limit"];
 
-await runner(Deno.args[0], defaultProcessor(selector, keys), defaultCleaner());
+await runner(Deno.args[0], defaultProcessor(selector, keys), defaultCleaner(), {
+  removeFile: true,
+});


### PR DESCRIPTION
```sh
$ plandex load "Error: Command failed: NO_COLOR=true deno run -q --allow-read --allow-write --allow-run --allow-net --allow-env --unstable ./src/processors/tfsa.ts ./raw/tfsa.html
Error: Expected exactly one table, but found 0
    at processTable (file:///home/runner/work/flat-canada-tax-coefficients/flat-canada-tax-coefficients/src/lib/runner.ts:105:11)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async file:///home/runner/work/flat-canada-tax-coefficients/flat-canada-tax-coefficients/src/lib/runner.ts:69:12
    at async runner (file:///home/runner/work/flat-canada-tax-coefficients/flat-canada-tax-coefficients/src/lib/runner.ts:29:21)
    at async file:///home/runner/work/flat-canada-tax-coefficients/flat-canada-tax-coefficients/src/processors/tfsa.ts:7:1"

$ plandex load "https://www.canada.ca/en/revenue-agency/services/tax/registered-plans-administrators/pspa/mp-rrsp-dpsp-tfsa-limits-ympe.html"
$ plandex tell "Fix the TFSA scraper."
```

:shrug: